### PR TITLE
Add ability to specify zoom level

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -119,10 +119,10 @@ function initMap() {
     // eslint-disable-line no-unused-vars
     map = new google.maps.Map(document.getElementById('map'), {
         center: {
-            lat: centerLat,
-            lng: centerLng
+            lat: Number(getParameterByName('lat')) || centerLat,
+            lng: Number(getParameterByName('lon')) || centerLng
         },
-        zoom: Store.get('zoomLevel'),
+        zoom: Number(getParameterByName('zoom')) || Store.get('zoomLevel'),
         fullscreenControl: true,
         streetViewControl: false,
         mapTypeControl: false,
@@ -1643,6 +1643,23 @@ function toggleGymPokemonDetails(e) {
     e.lastElementChild.firstElementChild.classList.toggle('fa-angle-double-down');
     e.nextElementSibling.classList.toggle('visible');
 }
+
+function getParameterByName(name, url) {
+    if (!url) {
+        url = window.location.search
+    }
+    name = name.replace(/[[\]]/g, '\\$&')
+    var regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)')
+    var results = regex.exec(url)
+    if (!results) {
+        return null
+    }
+    if (!results[2]) {
+        return ''
+    }
+    return decodeURIComponent(results[2].replace(/\+/g, ' '))
+}
+
 
 //
 // Page Ready Exection


### PR DESCRIPTION
Copy of a PR on RM.

I thought about adding this pull request for those who utilize third party alarm systems such as pokealarm. Pokealarm has the ability to link users straight to google maps at GPS coordinates, however, having the ability to channel users to the map creators website could have a couple of benefits. One the website owner would be able to track hits from the pokealarm for statistical purposes. It would also allow for the most accurate time remaining and any additional info about Pokestops in the area and even other Pokemon in the nearby vicinity.

These changes add onto the already existing ability to append to ?lat={{lat}}&lon={{lon}} a &zoom={{zoom}}

