### PR TITLE
Show infoWindow on specific encounter when specified in querystring

### DIFF
--- a/lib/Monocle.php
+++ b/lib/Monocle.php
@@ -39,12 +39,7 @@ class Monocle extends Scanner
                 $i++;
             }
             $pkmn_in = substr($pkmn_in, 0, -1);
-            if ($encId != 0) {
-                $params[':qry_enc_id'] = $encId;
-                $conds[] = "(pokemon_id NOT IN ( $pkmn_in )) OR encounter_id = :qry_enc_id";
-            } else {
-                $conds[] = "(pokemon_id NOT IN ( $pkmn_in ))";
-            }
+            $conds[] = "(pokemon_id NOT IN ( $pkmn_in ))";
         }
         $float = $db->info()['driver'] == 'pgsql' ? "::float" : "";
         if (!empty($minIv) && !is_nan((float)$minIv) && $minIv != 0) {
@@ -54,7 +49,7 @@ class Monocle extends Scanner
                 $conds[] = '(((atk_iv' . $float . ' + def_iv' . $float . ' + sta_iv' . $float . ') / 45.00)' . $float . ' * 100.00 >= ' . $minIv . ' OR pokemon_id IN(' . $exMinIv . ') )';
             }
         }
-        return $this->query_active($select, $conds, $params);
+        return $this->query_active($select, $conds, $params, $encId);
     }
 
     public function get_active_by_id($ids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $swLat, $swLng, $neLat, $neLng)
@@ -97,7 +92,7 @@ class Monocle extends Scanner
         return $this->query_active($select, $conds, $params);
     }
 
-    public function query_active($select, $conds, $params)
+    public function query_active($select, $conds, $params, $encId = 0)
     {
         global $db;
 
@@ -105,8 +100,12 @@ class Monocle extends Scanner
         FROM sightings 
         WHERE :conditions";
 
+        $tmpSQL = '';
+        if ($encId != 0) {
+            $tmpSQL = " OR encounter_id = " . $encId;
+        }
         $query = str_replace(":select", $select, $query);
-        $query = str_replace(":conditions", join(" AND ", $conds), $query);
+        $query = str_replace(":conditions", '(' . join(" AND ", $conds) . ')' . $tmpSQL, $query);
         $pokemons = $db->query($query, $params)->fetchAll(\PDO::FETCH_ASSOC);
         $data = array();
         $i = 0;
@@ -437,6 +436,7 @@ class Monocle extends Scanner
         }
         return $data;
     }
+
     public function get_weather_by_cell_id($cell_id)
     {
         global $db;
@@ -449,7 +449,8 @@ class Monocle extends Scanner
             return null;
         }
     }
-    public function get_weather($updated=null)
+
+    public function get_weather($updated = null)
     {
         global $db;
         $query = "SELECT * FROM weather WHERE :conditions ORDER BY id ASC";
@@ -463,7 +464,7 @@ class Monocle extends Scanner
         $query = str_replace(":conditions", join(" AND ", $conds), $query);
         $weathers = $db->query($query, $params)->fetchAll(\PDO::FETCH_ASSOC);
         foreach ($weathers as $weather) {
-            $data["weather_".$weather['s2_cell_id']] = $weather;
+            $data["weather_" . $weather['s2_cell_id']] = $weather;
         }
         return $data;
     }

--- a/lib/Monocle.php
+++ b/lib/Monocle.php
@@ -4,7 +4,7 @@ namespace Scanner;
 
 class Monocle extends Scanner
 {
-    public function get_active($eids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $swLat, $swLng, $neLat, $neLng, $tstamp = 0, $oSwLat = 0, $oSwLng = 0, $oNeLat = 0, $oNeLng = 0)
+    public function get_active($eids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $swLat, $swLng, $neLat, $neLng, $tstamp = 0, $oSwLat = 0, $oSwLng = 0, $oNeLat = 0, $oNeLng = 0, $encId = 0)
     {
         global $db;
         $conds = array();
@@ -39,7 +39,12 @@ class Monocle extends Scanner
                 $i++;
             }
             $pkmn_in = substr($pkmn_in, 0, -1);
-            $conds[] = "pokemon_id NOT IN ( $pkmn_in )";
+			if ($encId != 0) {
+                $params[':qry_enc_id'] = $encId;
+                $conds[] = "(pokemon_id NOT IN ( $pkmn_in )) OR encounter_id = :qry_enc_id";
+            } else {
+                $conds[] = "(pokemon_id NOT IN ( $pkmn_in ))";
+            }
         }
         $float = $db->info()['driver'] == 'pgsql' ? "::float" : "";
         if (!empty($minIv) && !is_nan((float)$minIv) && $minIv != 0) {

--- a/lib/Monocle.php
+++ b/lib/Monocle.php
@@ -39,7 +39,7 @@ class Monocle extends Scanner
                 $i++;
             }
             $pkmn_in = substr($pkmn_in, 0, -1);
-			if ($encId != 0) {
+            if ($encId != 0) {
                 $params[':qry_enc_id'] = $encId;
                 $conds[] = "(pokemon_id NOT IN ( $pkmn_in )) OR encounter_id = :qry_enc_id";
             } else {

--- a/lib/Monocle_Alternate.php
+++ b/lib/Monocle_Alternate.php
@@ -38,11 +38,11 @@ class Monocle_Alternate extends Monocle
         if (count($eids)) {
             $tmpSQL = '';
             if (!empty($tinyRat) && $tinyRat === 'true' && ($key = array_search("19", $eids)) === false) {
-                $tmpSQL .= ' || (pokemon_id = 19 && weight' . $float . ' < 2.41)';
+                $tmpSQL .= ' OR (pokemon_id = 19 AND weight' . $float . ' < 2.41)';
                 $eids[] = "19";
             }
             if (!empty($bigKarp) && $bigKarp === 'true' && ($key = array_search("129", $eids)) === false) {
-                $tmpSQL .= ' || (pokemon_id = 129 && weight' . $float . ' > 13.13)';
+                $tmpSQL .= ' OR (pokemon_id = 129 AND weight' . $float . ' > 13.13)';
                 $eids[] = "129";
             }
             $pkmn_in = '';
@@ -101,11 +101,11 @@ class Monocle_Alternate extends Monocle
         if (count($ids)) {
             $tmpSQL = '';
             if (!empty($tinyRat) && $tinyRat === 'true' && ($key = array_search("19", $ids)) === false) {
-                $tmpSQL .= ' || (pokemon_id = 19 && weight' . $float . ' < 2.41)';
+                $tmpSQL .= ' OR (pokemon_id = 19 AND weight' . $float . ' < 2.41)';
                 $eids[] = "19";
             }
             if (!empty($bigKarp) && $bigKarp === 'true' && ($key = array_search("129", $ids)) === false) {
-                $tmpSQL .= ' || (pokemon_id = 129 && weight' . $float . ' > 13.13)';
+                $tmpSQL .= ' OR (pokemon_id = 129 AND weight' . $float . ' > 13.13)';
                 $eids[] = "129";
             }
             $pkmn_in = '';

--- a/lib/Monocle_Alternate.php
+++ b/lib/Monocle_Alternate.php
@@ -53,7 +53,7 @@ class Monocle_Alternate extends Monocle
             }
             $pkmn_in = substr($pkmn_in, 0, -1);
             if ($encId != 0) {
-              $params[':qry_enc_id' = $encId];
+              $params[':qry_enc_id'] = $encId;
               $conds[] = "pokemon_id NOT IN ( $pkmn_in ) OR encounter_id = :qry_enc_id" . $tmpSQL . ")";
             } else {
               $conds[] = "pokemon_id NOT IN ( $pkmn_in )" . $tmpSQL;

--- a/lib/Monocle_Alternate.php
+++ b/lib/Monocle_Alternate.php
@@ -54,7 +54,7 @@ class Monocle_Alternate extends Monocle
             $pkmn_in = substr($pkmn_in, 0, -1);
             if ($encId != 0) {
                 $params[':qry_enc_id'] = $encId;
-                $conds[] = "(pokemon_id NOT IN ( $pkmn_in ) OR encounter_id = :qry_enc_id" . $tmpSQL . ")";
+                $conds[] = "(pokemon_id NOT IN ( $pkmn_in ) " . $tmpSQL . ") OR encounter_id = :qry_enc_id";
             } else {
                 $conds[] = "(pokemon_id NOT IN ( $pkmn_in )" . $tmpSQL . ")";
             }

--- a/lib/Monocle_Alternate.php
+++ b/lib/Monocle_Alternate.php
@@ -52,13 +52,12 @@ class Monocle_Alternate extends Monocle
                 $i++;
             }
             $pkmn_in = substr($pkmn_in, 0, -1);
-			if ($encId != 0) {
-				$params[':qry_enc_id' = $encId];
-				$conds[] = "(pokemon_id NOT IN ( $pkmn_in ) OR encounter_id = :qry_enc_id)" . $tmpSQL;
-			}
-			else {
-				$conds[] = "pokemon_id NOT IN ( $pkmn_in )" . $tmpSQL;
-			}
+            if ($encId != 0) {
+              $params[':qry_enc_id' = $encId];
+              $conds[] = "pokemon_id NOT IN ( $pkmn_in ) OR encounter_id = :qry_enc_id" . $tmpSQL . ")";
+            } else {
+              $conds[] = "pokemon_id NOT IN ( $pkmn_in )" . $tmpSQL;
+            }
         }
         $float = $db->info()['driver'] == 'pgsql' ? "::float" : "";
         if (!empty($minIv) && !is_nan((float)$minIv) && $minIv != 0) {

--- a/lib/Monocle_Alternate.php
+++ b/lib/Monocle_Alternate.php
@@ -53,12 +53,7 @@ class Monocle_Alternate extends Monocle
                 $i++;
             }
             $pkmn_in = substr($pkmn_in, 0, -1);
-            if ($encId != 0) {
-                $params[':qry_enc_id'] = $encId;
-                $conds[] = "(pokemon_id NOT IN ( $pkmn_in ) " . $tmpSQL . ") OR encounter_id = :qry_enc_id";
-            } else {
-                $conds[] = "(pokemon_id NOT IN ( $pkmn_in )" . $tmpSQL . ")";
-            }
+            $conds[] = "(pokemon_id NOT IN ( $pkmn_in )" . $tmpSQL . ")";
         }
         if (!empty($minIv) && !is_nan((float)$minIv) && $minIv != 0) {
             if (empty($exMinIv)) {
@@ -75,7 +70,7 @@ class Monocle_Alternate extends Monocle
             }
         }
 
-        return $this->query_active($select, $conds, $params);
+        return $this->query_active($select, $conds, $params, $encId);
     }
 
     public function get_active_by_id($ids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $swLat, $swLng, $neLat, $neLng)

--- a/lib/Monocle_Alternate.php
+++ b/lib/Monocle_Alternate.php
@@ -9,6 +9,7 @@ class Monocle_Alternate extends Monocle
         global $db;
         $conds = array();
         $params = array();
+        $float = $db->info()['driver'] == 'pgsql' ? "::float" : "";
 
         $select = "pokemon_id, expire_timestamp AS disappear_time, encounter_id, lat AS latitude, lon AS longitude, gender, form, weight, weather_boosted_condition";
         global $noHighLevelData;
@@ -37,11 +38,11 @@ class Monocle_Alternate extends Monocle
         if (count($eids)) {
             $tmpSQL = '';
             if (!empty($tinyRat) && $tinyRat === 'true' && ($key = array_search("19", $eids)) === false) {
-                $tmpSQL .= ' || (pokemon_id = 19 && weight < 2.41)';
+                $tmpSQL .= ' || (pokemon_id = 19 && weight' . $float . ' < 2.41)';
                 $eids[] = "19";
             }
             if (!empty($bigKarp) && $bigKarp === 'true' && ($key = array_search("129", $eids)) === false) {
-                $tmpSQL .= ' || (pokemon_id = 129 && weight > 13.13)';
+                $tmpSQL .= ' || (pokemon_id = 129 && weight' . $float . ' > 13.13)';
                 $eids[] = "129";
             }
             $pkmn_in = '';
@@ -59,7 +60,6 @@ class Monocle_Alternate extends Monocle
                 $conds[] = "(pokemon_id NOT IN ( $pkmn_in )" . $tmpSQL . ")";
             }
         }
-        $float = $db->info()['driver'] == 'pgsql' ? "::float" : "";
         if (!empty($minIv) && !is_nan((float)$minIv) && $minIv != 0) {
             if (empty($exMinIv)) {
                 $conds[] = '((atk_iv' . $float . ' + def_iv' . $float . ' + sta_iv' . $float . ') / 45.00)' . $float . ' * 100.00 >= ' . $minIv;

--- a/lib/Monocle_Alternate.php
+++ b/lib/Monocle_Alternate.php
@@ -4,7 +4,7 @@ namespace Scanner;
 
 class Monocle_Alternate extends Monocle
 {
-    public function get_active($eids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $swLat, $swLng, $neLat, $neLng, $tstamp = 0, $oSwLat = 0, $oSwLng = 0, $oNeLat = 0, $oNeLng = 0)
+    public function get_active($eids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $swLat, $swLng, $neLat, $neLng, $tstamp = 0, $oSwLat = 0, $oSwLng = 0, $oNeLat = 0, $oNeLng = 0, $encId = 0)
     {
         global $db;
         $conds = array();
@@ -52,7 +52,13 @@ class Monocle_Alternate extends Monocle
                 $i++;
             }
             $pkmn_in = substr($pkmn_in, 0, -1);
-            $conds[] = "pokemon_id NOT IN ( $pkmn_in )" . $tmpSQL;
+			if ($encId != 0) {
+				$params[':qry_enc_id' = $encId];
+				$conds[] = "(pokemon_id NOT IN ( $pkmn_in ) OR encounter_id = :qry_enc_id)" . $tmpSQL;
+			}
+			else {
+				$conds[] = "pokemon_id NOT IN ( $pkmn_in )" . $tmpSQL;
+			}
         }
         $float = $db->info()['driver'] == 'pgsql' ? "::float" : "";
         if (!empty($minIv) && !is_nan((float)$minIv) && $minIv != 0) {

--- a/lib/Monocle_Alternate.php
+++ b/lib/Monocle_Alternate.php
@@ -53,10 +53,10 @@ class Monocle_Alternate extends Monocle
             }
             $pkmn_in = substr($pkmn_in, 0, -1);
             if ($encId != 0) {
-              $params[':qry_enc_id'] = $encId;
-              $conds[] = "pokemon_id NOT IN ( $pkmn_in ) OR encounter_id = :qry_enc_id" . $tmpSQL . ")";
+                $params[':qry_enc_id'] = $encId;
+                $conds[] = "pokemon_id NOT IN ( $pkmn_in ) OR encounter_id = :qry_enc_id" . $tmpSQL . ")";
             } else {
-              $conds[] = "pokemon_id NOT IN ( $pkmn_in )" . $tmpSQL;
+                $conds[] = "pokemon_id NOT IN ( $pkmn_in )" . $tmpSQL;
             }
         }
         $float = $db->info()['driver'] == 'pgsql' ? "::float" : "";

--- a/lib/Monocle_Asner.php
+++ b/lib/Monocle_Asner.php
@@ -4,7 +4,7 @@ namespace Scanner;
 
 class Monocle_Asner extends Monocle
 {
-    public function get_active($eids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $swLat, $swLng, $neLat, $neLng, $tstamp = 0, $oSwLat = 0, $oSwLng = 0, $oNeLat = 0, $oNeLng = 0)
+    public function get_active($eids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $swLat, $swLng, $neLat, $neLng, $tstamp = 0, $oSwLat = 0, $oSwLng = 0, $oNeLat = 0, $oNeLng = 0, $encId = 0)
     {
         global $db;
         $conds = array();
@@ -39,7 +39,12 @@ class Monocle_Asner extends Monocle
                 $i++;
             }
             $pkmn_in = substr($pkmn_in, 0, -1);
-            $conds[] = "pokemon_id NOT IN ( $pkmn_in )";
+			if ($encId != 0) {
+                $params[':qry_enc_id'] = $encId;
+                $conds[] = "(pokemon_id NOT IN ( $pkmn_in )) OR encounter_id = :qry_enc_id";
+            } else {
+                $conds[] = "(pokemon_id NOT IN ( $pkmn_in ))";
+            }
         }
         $float = $db->info()['driver'] == 'pgsql' ? "::float" : "";
         if (!empty($minIv) && !is_nan((float)$minIv) && $minIv != 0) {

--- a/lib/Monocle_Asner.php
+++ b/lib/Monocle_Asner.php
@@ -39,12 +39,7 @@ class Monocle_Asner extends Monocle
                 $i++;
             }
             $pkmn_in = substr($pkmn_in, 0, -1);
-            if ($encId != 0) {
-                $params[':qry_enc_id'] = $encId;
-                $conds[] = "(pokemon_id NOT IN ( $pkmn_in )) OR encounter_id = :qry_enc_id";
-            } else {
-                $conds[] = "(pokemon_id NOT IN ( $pkmn_in ))";
-            }
+            $conds[] = "(pokemon_id NOT IN ( $pkmn_in ))";
         }
         $float = $db->info()['driver'] == 'pgsql' ? "::float" : "";
         if (!empty($minIv) && !is_nan((float)$minIv) && $minIv != 0) {
@@ -62,7 +57,7 @@ class Monocle_Asner extends Monocle
             }
         }
 
-        return $this->query_active($select, $conds, $params);
+        return $this->query_active($select, $conds, $params, $encId);
     }
 
     public function get_active_by_id($ids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $swLat, $swLng, $neLat, $neLng)

--- a/lib/Monocle_Asner.php
+++ b/lib/Monocle_Asner.php
@@ -39,7 +39,7 @@ class Monocle_Asner extends Monocle
                 $i++;
             }
             $pkmn_in = substr($pkmn_in, 0, -1);
-			if ($encId != 0) {
+            if ($encId != 0) {
                 $params[':qry_enc_id'] = $encId;
                 $conds[] = "(pokemon_id NOT IN ( $pkmn_in )) OR encounter_id = :qry_enc_id";
             } else {

--- a/lib/RocketMap.php
+++ b/lib/RocketMap.php
@@ -94,7 +94,7 @@ class RocketMap extends Scanner
         global $db;
         $conds = array();
         $params = array();
-		$float = $db->info()['driver'] == 'pgsql' ? "::float" : "";
+        $float = $db->info()['driver'] == 'pgsql' ? "::float" : "";
 
         $select = "pokemon_id, Unix_timestamp(Convert_tz(disappear_time, '+00:00', @@global.time_zone)) AS disappear_time, encounter_id, latitude, longitude, gender, form, weight, height";
         global $noHighLevelData;

--- a/lib/RocketMap_Sloppy.php
+++ b/lib/RocketMap_Sloppy.php
@@ -5,7 +5,7 @@ namespace Scanner;
 class RocketMap_Sloppy extends RocketMap
 {
     // This is based on assumption from the last version I saw
-    public function get_active($eids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $swLat, $swLng, $neLat, $neLng, $tstamp = 0, $oSwLat = 0, $oSwLng = 0, $oNeLat = 0, $oNeLng = 0)
+    public function get_active($eids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $swLat, $swLng, $neLat, $neLng, $tstamp = 0, $oSwLat = 0, $oSwLng = 0, $oNeLat = 0, $oNeLng = 0, $encId = 0)
     {
         global $db;
         $conds = array();
@@ -43,11 +43,11 @@ class RocketMap_Sloppy extends RocketMap
         if (count($eids)) {
             $tmpSQL = '';
             if (!empty($tinyRat) && $tinyRat === 'true' && ($key = array_search("19", $eids)) === false) {
-                $tmpSQL .= ' || (pokemon_id = 19 && weight' . $float . ' < 2.41)';
+                $tmpSQL .= ' OR (pokemon_id = 19 AND weight' . $float . ' < 2.41)';
                 $eids[] = "19";
             }
             if (!empty($bigKarp) && $bigKarp === 'true' && ($key = array_search("129", $eids)) === false) {
-                $tmpSQL .= ' || (pokemon_id = 129 && weight' . $float . ' > 13.13)';
+                $tmpSQL .= ' OR (pokemon_id = 129 AND weight' . $float . ' > 13.13)';
                 $eids[] = "129";
             }
             $pkmn_in = '';
@@ -58,7 +58,12 @@ class RocketMap_Sloppy extends RocketMap
                 $i++;
             }
             $pkmn_in = substr($pkmn_in, 0, -1);
-            $conds[] = "(pokemon_id NOT IN ( $pkmn_in )" . $tmpSQL . ")";
+            if ($encId != 0) {
+                $params[':qry_enc_id'] = $encId;
+                $conds[] = "(pokemon_id NOT IN ( $pkmn_in ) " . $tmpSQL . ") OR encounter_id = :qry_enc_id";
+            } else {
+                $conds[] = "(pokemon_id NOT IN ( $pkmn_in )" . $tmpSQL . ")";
+            }
         }
 
         if (!empty($minIv) && !is_nan((float)$minIv) && $minIv != 0) {
@@ -83,6 +88,7 @@ class RocketMap_Sloppy extends RocketMap
         global $db;
         $conds = array();
         $params = array();
+        $float = $db->info()['driver'] == 'pgsql' ? "::float" : "";
 
         $select = "pokemon_id, Unix_timestamp(Convert_tz(disappear_time, '+00:00', @@global.time_zone)) AS disappear_time, encounter_id, latitude, longitude, gender, form, weight, height, weather_boosted_condition";
         global $noHighLevelData;
@@ -102,11 +108,11 @@ class RocketMap_Sloppy extends RocketMap
         if (count($ids)) {
             $tmpSQL = '';
             if (!empty($tinyRat) && $tinyRat === 'true' && ($key = array_search("19", $ids)) === false) {
-                $tmpSQL .= ' || (pokemon_id = 19 && weight < 2.41)';
+                $tmpSQL .= ' OR (pokemon_id = 19 AND weight' . $float . ' < 2.41)';
                 $eids[] = "19";
             }
             if (!empty($bigKarp) && $bigKarp === 'true' && ($key = array_search("129", $ids)) === false) {
-                $tmpSQL .= ' || (pokemon_id = 129 && weight > 13.13)';
+                $tmpSQL .= ' OR (pokemon_id = 129 AND weight' . $float . ' > 13.13)';
                 $eids[] = "129";
             }
             $pkmn_in = '';
@@ -119,7 +125,6 @@ class RocketMap_Sloppy extends RocketMap
             $pkmn_in = substr($pkmn_in, 0, -1);
             $conds[] = "(pokemon_id NOT IN ( $pkmn_in )" . $tmpSQL . ")";
         }
-        $float = $db->info()['driver'] == 'pgsql' ? "::float" : "";
         if (!empty($minIv) && !is_nan((float)$minIv) && $minIv != 0) {
             if (empty($exMinIv)) {
                 $conds[] = '((individual_attack' . $float . ' + individual_defense' . $float . ' + individual_stamina' . $float . ')' . $float . ' / 45.00) * 100.00 >= ' . $minIv;

--- a/lib/RocketMap_Sloppy.php
+++ b/lib/RocketMap_Sloppy.php
@@ -58,12 +58,7 @@ class RocketMap_Sloppy extends RocketMap
                 $i++;
             }
             $pkmn_in = substr($pkmn_in, 0, -1);
-            if ($encId != 0) {
-                $params[':qry_enc_id'] = $encId;
-                $conds[] = "(pokemon_id NOT IN ( $pkmn_in ) " . $tmpSQL . ") OR encounter_id = :qry_enc_id";
-            } else {
-                $conds[] = "(pokemon_id NOT IN ( $pkmn_in )" . $tmpSQL . ")";
-            }
+            $conds[] = "(pokemon_id NOT IN ( $pkmn_in )" . $tmpSQL . ")";
         }
 
         if (!empty($minIv) && !is_nan((float)$minIv) && $minIv != 0) {
@@ -80,7 +75,7 @@ class RocketMap_Sloppy extends RocketMap
                 $conds[] = '(cp_multiplier >= ' . $this->cpMultiplier[$minLevel] . ' OR pokemon_id IN(' . $exMinIv . ') )';
             }
         }
-        return $this->query_active($select, $conds, $params);
+        return $this->query_active($select, $conds, $params, $encId);
     }
 
     public function get_active_by_id($ids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $swLat, $swLng, $neLat, $neLng)

--- a/raw_data.php
+++ b/raw_data.php
@@ -41,7 +41,6 @@ $d["lastspawns"] = !empty($_POST['spawnpoints']) ? $_POST['spawnpoints'] : false
 $d["lastpokemon"] = !empty($_POST['pokemon']) ? $_POST['pokemon'] : false;
 if ($minIv < $prevMinIv || $minLevel < $prevMinLevel) {
     $lastpokemon = false;
-
 }
 $enc_id = !empty($_POST['encId']) ? $_POST['encId'] : null;
 

--- a/raw_data.php
+++ b/raw_data.php
@@ -106,9 +106,9 @@ if (!$noPokemon) {
             $d["pokemons"] = $scanner->get_active($eids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $swLat, $swLng, $neLat, $neLng);
         } else {
             if ($newarea) {
-                $d["pokemons"] = $scanner->get_active($eids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $swLat, $swLng, $neLat, $neLng, 0, $oSwLat, $oSwLng, $oNeLat, $oNeLng);
+                $d["pokemons"] = $scanner->get_active($eids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $swLat, $swLng, $neLat, $neLng, 0, $oSwLat, $oSwLng, $oNeLat, $oNeLng, $enc_id);
             } else {
-                $d["pokemons"] = $scanner->get_active($eids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $swLat, $swLng, $neLat, $neLng, $timestamp);
+                $d["pokemons"] = $scanner->get_active($eids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $swLat, $swLng, $neLat, $neLng, $timestamp, 0, 0, 0, 0, $enc_id);
             }
         }
         $d["preMinIV"] = $minIv;

--- a/raw_data.php
+++ b/raw_data.php
@@ -41,7 +41,9 @@ $d["lastspawns"] = !empty($_POST['spawnpoints']) ? $_POST['spawnpoints'] : false
 $d["lastpokemon"] = !empty($_POST['pokemon']) ? $_POST['pokemon'] : false;
 if ($minIv < $prevMinIv || $minLevel < $prevMinLevel) {
     $lastpokemon = false;
+
 }
+$enc_id = !empty($_POST['enc_id']) ? $_POST['enc_id'] : null;
 
 $timestamp = !empty($_POST['timestamp']) ? $_POST['timestamp'] : 0;
 
@@ -111,6 +113,25 @@ if (!$noPokemon) {
         }
         $d["preMinIV"] = $minIv;
         $d["preMinLevel"] = $minLevel;
+
+        if (!empty($_POST['eids'])) {
+            $eids = explode(",", $_POST['eids']);
+
+            foreach ($d['pokemons'] as $elementKey => $element) {
+                $ignoreExclusion = false;
+                foreach ($element as $valueKey => $value) {
+                    if ($valueKey == 'encounter_id') {
+                        $ignoreExclusion = $value == $enc_id;
+                    }
+                    elseif ($valueKey == 'pokemon_id') {
+                        if (!$ignoreExclusion && in_array($value, $eids)) {
+                            //delete this particular object from the $array
+                            unset($d['pokemons'][$elementKey]);
+                        }
+                    }
+                }
+            }
+        }
 
         if (!empty($_POST['reids'])) {
             $reids = !empty($_POST['reids']) ? explode(",", $_POST['reids']) : array();

--- a/raw_data.php
+++ b/raw_data.php
@@ -43,7 +43,7 @@ if ($minIv < $prevMinIv || $minLevel < $prevMinLevel) {
     $lastpokemon = false;
 
 }
-$enc_id = !empty($_POST['enc_id']) ? $_POST['enc_id'] : null;
+$enc_id = !empty($_POST['encId']) ? $_POST['encId'] : null;
 
 $timestamp = !empty($_POST['timestamp']) ? $_POST['timestamp'] : 0;
 

--- a/raw_data.php
+++ b/raw_data.php
@@ -122,8 +122,7 @@ if (!$noPokemon) {
                 foreach ($element as $valueKey => $value) {
                     if ($valueKey == 'encounter_id') {
                         $ignoreExclusion = $value == $enc_id;
-                    }
-                    elseif ($valueKey == 'pokemon_id') {
+                    } elseif ($valueKey == 'pokemon_id') {
                         if (!$ignoreExclusion && in_array($value, $eids)) {
                             //delete this particular object from the $array
                             unset($d['pokemons'][$elementKey]);

--- a/raw_data.php
+++ b/raw_data.php
@@ -102,7 +102,7 @@ if (!$noPokemon) {
     if ($d["lastpokemon"] == "true") {
         $eids = !empty($_POST['eids']) ? explode(",", $_POST['eids']) : array();
         if ($lastpokemon != 'true') {
-            $d["pokemons"] = $scanner->get_active($eids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $swLat, $swLng, $neLat, $neLng);
+            $d["pokemons"] = $scanner->get_active($eids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $swLat, $swLng, $neLat, $neLng, 0, 0, 0, 0, 0, $enc_id);
         } else {
             if ($newarea) {
                 $d["pokemons"] = $scanner->get_active($eids, $minIv, $minLevel, $exMinIv, $bigKarp, $tinyRat, $swLat, $swLng, $neLat, $neLng, 0, $oSwLat, $oSwLng, $oNeLat, $oNeLng, $enc_id);
@@ -112,25 +112,6 @@ if (!$noPokemon) {
         }
         $d["preMinIV"] = $minIv;
         $d["preMinLevel"] = $minLevel;
-
-        if (!empty($_POST['eids'])) {
-            $eids = explode(",", $_POST['eids']);
-
-            foreach ($d['pokemons'] as $elementKey => $element) {
-                $ignoreExclusion = false;
-                foreach ($element as $valueKey => $value) {
-                    if ($valueKey == 'encounter_id') {
-                        $ignoreExclusion = $value == $enc_id;
-                    } elseif ($valueKey == 'pokemon_id') {
-                        if (!$ignoreExclusion && in_array($value, $eids)) {
-                            //delete this particular object from the $array
-                            unset($d['pokemons'][$elementKey]);
-                        }
-                    }
-                }
-            }
-        }
-
         if (!empty($_POST['reids'])) {
             $reids = !empty($_POST['reids']) ? explode(",", $_POST['reids']) : array();
 

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1315,9 +1315,9 @@ function addListeners(marker) {
 }
 
 function clearStaleMarkers() {
-    var enc_id = getParameterByName('enc_id');
+    var encounterId = getParameterByName('encId')
     $.each(mapData.pokemons, function (key, value) {
-        if (mapData.pokemons[key]['disappear_time'] < new Date().getTime() || (excludedPokemon.indexOf(mapData.pokemons[key]['pokemon_id']) >= 0 && ((enc_id && enc_id != mapData.pokemons[key]['encounter_id']) || !enc_id)) || isTemporaryHidden(mapData.pokemons[key]['pokemon_id']) || ((((mapData.pokemons[key]['individual_attack'] + mapData.pokemons[key]['individual_defense'] + mapData.pokemons[key]['individual_stamina']) / 45 * 100 < minIV) || ((mapType === 'monocle' && mapData.pokemons[key]['level'] < minLevel) || (mapType === 'rm' && !isNaN(minLevel) && (mapData.pokemons[key]['cp_multiplier'] < cpMultiplier[minLevel - 1])))) && !excludedMinIV.includes(mapData.pokemons[key]['pokemon_id'])) || (Store.get('showBigKarp') === true && mapData.pokemons[key]['pokemon_id'] === 129 && (mapData.pokemons[key]['weight'] < 13.14 || mapData.pokemons[key]['weight'] === null)) || (Store.get('showTinyRat') === true && mapData.pokemons[key]['pokemon_id'] === 19 && (mapData.pokemons[key]['weight'] > 2.40 || mapData.pokemons[key]['weight'] === null))) {
+        if (mapData.pokemons[key]['disappear_time'] < new Date().getTime() || (excludedPokemon.indexOf(mapData.pokemons[key]['pokemon_id']) >= 0 && ((encounterId && encounterId !== mapData.pokemons[key]['encounter_id']) || !encounterId)) || isTemporaryHidden(mapData.pokemons[key]['pokemon_id']) || ((((mapData.pokemons[key]['individual_attack'] + mapData.pokemons[key]['individual_defense'] + mapData.pokemons[key]['individual_stamina']) / 45 * 100 < minIV) || ((mapType === 'monocle' && mapData.pokemons[key]['level'] < minLevel) || (mapType === 'rm' && !isNaN(minLevel) && (mapData.pokemons[key]['cp_multiplier'] < cpMultiplier[minLevel - 1])))) && !excludedMinIV.includes(mapData.pokemons[key]['pokemon_id'])) || (Store.get('showBigKarp') === true && mapData.pokemons[key]['pokemon_id'] === 129 && (mapData.pokemons[key]['weight'] < 13.14 || mapData.pokemons[key]['weight'] === null)) || (Store.get('showTinyRat') === true && mapData.pokemons[key]['pokemon_id'] === 19 && (mapData.pokemons[key]['weight'] > 2.40 || mapData.pokemons[key]['weight'] === null))) {
             if (mapData.pokemons[key].marker.rangeCircle) {
                 mapData.pokemons[key].marker.rangeCircle.setMap(null)
                 delete mapData.pokemons[key].marker.rangeCircle
@@ -1328,7 +1328,7 @@ function clearStaleMarkers() {
     })
 
     $.each(mapData.lurePokemons, function (key, value) {
-        if (mapData.lurePokemons[key]['lure_expiration'] < new Date().getTime() || (excludedPokemon.indexOf(mapData.lurePokemons[key]['pokemon_id']) >= 0 && ((enc_id && enc_id != mapData.pokemons[key]['encounter_id']) || !enc_id))) {
+        if (mapData.lurePokemons[key]['lure_expiration'] < new Date().getTime() || (excludedPokemon.indexOf(mapData.lurePokemons[key]['pokemon_id']) >= 0 && ((encounterId && encounterId !== mapData.pokemons[key]['encounter_id']) || !encounterId))) {
             mapData.lurePokemons[key].marker.setMap(null)
             delete mapData.lurePokemons[key]
         }
@@ -1450,7 +1450,7 @@ function loadRawData() {
             'eids': String(excludedPokemon),
             'exMinIV': String(excludedMinIV),
             'token': token,
-            'enc_id': getParameterByName('enc_id')
+            'encId': getParameterByName('encId')
         },
         dataType: 'json',
         cache: false,
@@ -1581,13 +1581,13 @@ function loadWeatherCellData(cell) {
 }
 	
 function getParameterByName(name, url) {
-    if (!url) url = window.location.href;
-    name = name.replace(/[\[\]]/g, "\\$&");
-    var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
-        results = regex.exec(url);
-    if (!results) return null;
-    if (!results[2]) return '';
-    return decodeURIComponent(results[2].replace(/\+/g, " "));
+    if (!url) url = window.location.href
+    name = name.replace(/[\[\]]/g, '\\$&')
+    var regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)')
+    var results = regex.exec(url);
+    if (!results) return null
+    if (!results[2]) return ''
+    return decodeURIComponent(results[2].replace(/\+/g, ' '))
 }
 
 function processPokemons(i, item) {
@@ -1595,8 +1595,8 @@ function processPokemons(i, item) {
         return false // in case the checkbox was unchecked in the meantime.
     }
 
-    var enc_id = getParameterByName('enc_id');
-    if (!(item['encounter_id'] in mapData.pokemons) && item['disappear_time'] > Date.now() && ((enc_id && enc_id == item['encounter_id']) || (excludedPokemon.indexOf(item['pokemon_id']) < 0 && !isTemporaryHidden(item['pokemon_id'])))) {
+    var encounterId = getParameterByName('encId')
+    if (!(item['encounter_id'] in mapData.pokemons) && item['disappear_time'] > Date.now() && ((encounterId && encounterId === item['encounter_id']) || (excludedPokemon.indexOf(item['pokemon_id']) < 0 && !isTemporaryHidden(item['pokemon_id'])))) {
         // add marker to map and item to dict
         if (item.marker) {
             item.marker.setMap(null)
@@ -1607,7 +1607,7 @@ function processPokemons(i, item) {
             mapData.pokemons[item['encounter_id']] = item
         }
 
-        if (enc_id && enc_id == item['encounter_id']) {
+        if (encounterId && encounterId === item['encounter_id']) {
             if (!item.marker.infoWindowIsOpen) {
                 item.marker.infoWindow.open(map, item.marker)
                 clearSelection()
@@ -1620,7 +1620,6 @@ function processPokemons(i, item) {
                 item.marker.infoWindowIsOpen = false
             }
         }
-
     }
 }
 

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1579,7 +1579,7 @@ function loadWeatherCellData(cell) {
         }
     })
 }
-	
+
 function getParameterByName(name, url) {
     if (!url) url = window.location.href
     name = name.replace(/[[\]]/g, '\\$&')

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1582,9 +1582,9 @@ function loadWeatherCellData(cell) {
 	
 function getParameterByName(name, url) {
     if (!url) url = window.location.href
-    name = name.replace(/[\[\]]/g, '\\$&')
+    name = name.replace(/[[\]]/g, '\\$&')
     var regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)')
-    var results = regex.exec(url);
+    var results = regex.exec(url)
     if (!results) return null
     if (!results[2]) return ''
     return decodeURIComponent(results[2].replace(/\+/g, ' '))


### PR DESCRIPTION
If you have any alerts displaying to a user of a specific pokemon, you would usually link to a google maps link.  For those of you that want to link back to your map in those alerts and have the infoWindow open upon entry of the map, you can include the encounter_id in the url in the following format:

http(s)://host_name/?lat=##.###&lon=-##.###&encId=#########&zoom=16

The "encId" querystring parameter is used to pass the encounter id to the map.  

Note:  This is to be used in conjunction with passing the lat and lon.  Also, if a user has the alerted pokemon hidden on the map, this will show the particular pokemon associated with the encounter id, regardless of user setting.