### PR TITLE
Added fix to show gyms with raids when only gyms enabled

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1481,10 +1481,8 @@ function processGyms(i, item) {
     }
 
     if (Store.get('showGyms') && !Store.get('showRaids')) {
-        if (item.raid_end > Date.now()) {
-            removeGymFromMap(item['gym_id'])
-            return true
-        }
+        item.raid_end = 0
+        item.raid_level = item.raid_pokemon_cp = item.raid_pokemon_id = item.raid_pokemon_move_1 = item.raid_pokemon_move_1 = item.raid_pokemon_name = null
     }
 
     if (Store.get('activeRaids') && item.raid_end > Date.now()) {


### PR DESCRIPTION
Fixes bug whereby gyms that have raids (either egg or active) don't appear when only gyms are ticked.

Temporary fix until we think of something more permanent. What it does right now is unsets the raid data.