### PR TITLE
Support for OpenStreetMap Tileservers

### DIFF
--- a/config/default.php
+++ b/config/default.php
@@ -150,7 +150,7 @@ $criesSound = 'false';                                             // true/false
 $copyrightSafe = true;
 
 $noMapStyle = false;                                                // true/false
-$mapStyle = 'style_pgo_dynamic';                                    // roadmap, satellite, hybrid, nolabels_style, dark_style, style_light2, style_pgo, dark_style_nl, style_pgo_day, style_pgo_night, style_pgo_dynamic
+$mapStyle = 'style_pgo_dynamic';                                    // roadmap, satellite, hybrid, nolabels_style, dark_style, style_light2, style_pgo, dark_style_nl, style_pgo_day, style_pgo_night, style_pgo_dynamic, openstreetmap
 
 $noIconSize = false;                                                // true/false
 $iconSize = 0;                                                      // -8, 0, 10, 20
@@ -161,6 +161,7 @@ $gymStyle = 'ingame';                                               // ingame, s
 $noLocationStyle = false;                                           // true/false
 $locationStyle = 'none';                                            // none, google, red, red_animated, blue, blue_animated, yellow, yellow_animated, pokesition, pokeball
 
+$osmTileServer = 'tile.openstreetmap.org';                          // osm tile server (no trailing slash)
 
 //-----------------------------------------------------
 // Raid API

--- a/config/example.config.php
+++ b/config/example.config.php
@@ -150,6 +150,7 @@ $gymStyle = 'ingame';                                               // ingame, s
 $noLocationStyle = false;                                           // true/false
 $locationStyle = 'none';                                            // none, google, red, red_animated, blue, blue_animated, yellow, yellow_animated, pokesition, pokeball
 
+$osmTileServer = 'tile.openstreetmap.org';                          // osm tile server (no trailing slash)
 
 //-----------------------------------------------
 // Raid API

--- a/pre-index.php
+++ b/pre-index.php
@@ -665,6 +665,7 @@ if ($blockIframe) {
     var minZoom = <?= $maxZoomOut; ?>;
     var maxLatLng = <?= $maxLatLng; ?>;
 
+    var osmTileServer = '<?php echo $osmTileServer; ?>';
     var mapStyle = '<?php echo $mapStyle ?>';
     var hidePokemon = <?php echo $noHidePokemon ? '[]' : $hidePokemon ?>;
     var notifyPokemon = <?php echo $noNotifyPokemon ? '[]' : $notifyPokemon ?>;

--- a/static/data/mapstyle.json
+++ b/static/data/mapstyle.json
@@ -12,5 +12,5 @@
   "style_pgo_day": "Pokémon Go Day",
   "style_pgo_night": "Pokémon Go Night",
   "style_pgo_dynamic": "Pokémon Go Dynamic",
-  "osm": "OpenStreetMap"
+  "openstreetmap": "OpenStreetMap"
 }

--- a/static/data/mapstyle.json
+++ b/static/data/mapstyle.json
@@ -11,5 +11,6 @@
   "style_pgo_nl": "Pokémon Go (No Labels)",
   "style_pgo_day": "Pokémon Go Day",
   "style_pgo_night": "Pokémon Go Night",
-  "style_pgo_dynamic": "Pokémon Go Dynamic"
+  "style_pgo_dynamic": "Pokémon Go Dynamic",
+  "osm": "OpenStreetMap"
 }

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -205,9 +205,9 @@ function initMap() { // eslint-disable-line no-unused-vars
     map.mapTypes.set('style_pgo_night', stylePgoNight)
 
     // OpenStreetMap support
-    map.mapTypes.set("osm", new google.maps.ImageMapType({
+    map.mapTypes.set("openstreetmap", new google.maps.ImageMapType({
         getTileUrl: function(coord, zoom) {
-            return "//tile.openstreetmap.org/" + zoom + "/" + coord.x + "/" + coord.y + ".png";
+            return "//" + osmTileServer + "/" + zoom + "/" + coord.x + "/" + coord.y + ".png";
         },
         tileSize: new google.maps.Size(256, 256),
         name: "OpenStreetMap",

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -208,7 +208,7 @@ function initMap() { // eslint-disable-line no-unused-vars
     // OpenStreetMap support
     map.mapTypes.set('openstreetmap', new google.maps.ImageMapType({
         getTileUrl: function (coord, zoom) {
-            return '//' + osmTileServer + '/' + zoom + '.' + coord.x + '.' + coord.y + '.png'
+            return '//' + osmTileServer + '/' + zoom + '/' + coord.x + '/' + coord.y + '.png'
         },
         tileSize: new google.maps.Size(256, 256),
         name: 'OpenStreetMap',

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -153,7 +153,8 @@ function initMap() { // eslint-disable-line no-unused-vars
                 'style_pgo_nl',
                 'style_pgo_day',
                 'style_pgo_night',
-                'style_pgo_dynamic'
+                'style_pgo_dynamic',
+                'osm'
             ]
         }
     })
@@ -202,6 +203,16 @@ function initMap() { // eslint-disable-line no-unused-vars
         name: 'PokemonGo Night'
     })
     map.mapTypes.set('style_pgo_night', stylePgoNight)
+
+    // OpenStreetMap support
+    map.mapTypes.set("osm", new google.maps.ImageMapType({
+        getTileUrl: function(coord, zoom) {
+            return "//tile.openstreetmap.org/" + zoom + "/" + coord.x + "/" + coord.y + ".png";
+        },
+        tileSize: new google.maps.Size(256, 256),
+        name: "OpenStreetMap",
+        maxZoom: 18
+    }))
 
     // dynamic map style chooses stylePgoDay or stylePgoNight depending on client time
     var currentDate = new Date()

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -48,6 +48,7 @@ var rangeMarkers = ['pokemon', 'pokestop', 'gym']
 var storeZoom = true
 var scanPath
 var moves
+var osmTileServer
 
 var oSwLat
 var oSwLng
@@ -205,12 +206,12 @@ function initMap() { // eslint-disable-line no-unused-vars
     map.mapTypes.set('style_pgo_night', stylePgoNight)
 
     // OpenStreetMap support
-    map.mapTypes.set("openstreetmap", new google.maps.ImageMapType({
-        getTileUrl: function(coord, zoom) {
-            return "//" + osmTileServer + "/" + zoom + "/" + coord.x + "/" + coord.y + ".png";
+    map.mapTypes.set('openstreetmap', new google.maps.ImageMapType({
+        getTileUrl: function (coord, zoom) {
+            return '//' + osmTileServer + '/' + zoom + '.' + coord.x + '.' + coord.y + '.png'
         },
         tileSize: new google.maps.Size(256, 256),
-        name: "OpenStreetMap",
+        name: 'OpenStreetMap',
         maxZoom: 18
     }))
 


### PR DESCRIPTION
Added to give users more choice with which map service they'd like to use.

Also as PoGo uses OSM for determining which areas are parks, this is useful for finding out if a gym is within the bounds of a park *(EX raids, yo)*.

**Config change:**
Adds `$osmTileServer`, default is `'tile.openstreetmap.org'`
There are plenty of other tile providers should you wish to utilise them.