### PR TITLE
Notify on 0 iv toggle switch

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -72,6 +72,7 @@
     "notifyPokemon": true,
     "notifyRarity": true,
     "notifyIv": true,
+    "notifyIv0": true,
     "notifyLevel": true,
     "notifyRaid": true,
     "enableRaids": true,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -72,7 +72,7 @@
     "notifyPokemon": true,
     "notifyRarity": true,
     "notifyIv": true,
-    "notifyIv0": true,
+    "notifyIvZero": true,
     "notifyLevel": true,
     "notifyRaid": true,
     "enableRaids": true,

--- a/config/default.php
+++ b/config/default.php
@@ -137,7 +137,7 @@ $noNotifyIv = false;                                                // true/fals
 $notifyIv = '""';                                                   // "" for empty or a number
 
 $noNotifyIvZero = false;                                                // true/false
-$notifyIvZero = false;                                                // true/false
+$notifyIvZero = 'false';                                                // true/false
 
 $noNotifyLevel = false;                                                // true/false
 $notifyLevel = '""';                                                   // "" for empty or a number

--- a/config/default.php
+++ b/config/default.php
@@ -136,6 +136,9 @@ $notifyRarity = '[]';                                               // "Common",
 $noNotifyIv = false;                                                // true/false
 $notifyIv = '""';                                                   // "" for empty or a number
 
+$noNotifyIv0 = false;                                                // true/false
+$notifyIv0 = false;                                                // true/false
+
 $noNotifyLevel = false;                                                // true/false
 $notifyLevel = '""';                                                   // "" for empty or a number
 

--- a/config/default.php
+++ b/config/default.php
@@ -136,8 +136,8 @@ $notifyRarity = '[]';                                               // "Common",
 $noNotifyIv = false;                                                // true/false
 $notifyIv = '""';                                                   // "" for empty or a number
 
-$noNotifyIv0 = false;                                                // true/false
-$notifyIv0 = false;                                                // true/false
+$noNotifyIvZero = false;                                                // true/false
+$notifyIvZero = false;                                                // true/false
 
 $noNotifyLevel = false;                                                // true/false
 $notifyLevel = '""';                                                   // "" for empty or a number

--- a/config/example.config.php
+++ b/config/example.config.php
@@ -125,8 +125,8 @@ $notifyRarity = '[]';                                               // "Common",
 $noNotifyIv = false;                                                // true/false
 $notifyIv = '""';                                                   // "" for empty or a number
 
-$noNotifyIv0 = false;                                                // true/false
-$notifyIv0 = false;                                                // true/false
+$noNotifyIvZero = false;                                                // true/false
+$notifyIvZero = false;                                                // true/false
 
 $noNotifyLevel = false;                                                // true/false
 $notifyLevel = '""';                                                   // "" for empty or a number

--- a/config/example.config.php
+++ b/config/example.config.php
@@ -126,7 +126,7 @@ $noNotifyIv = false;                                                // true/fals
 $notifyIv = '""';                                                   // "" for empty or a number
 
 $noNotifyIvZero = false;                                                // true/false
-$notifyIvZero = false;                                                // true/false
+$notifyIvZero = 'false';                                                // true/false
 
 $noNotifyLevel = false;                                                // true/false
 $notifyLevel = '""';                                                   // "" for empty or a number

--- a/config/example.config.php
+++ b/config/example.config.php
@@ -125,6 +125,9 @@ $notifyRarity = '[]';                                               // "Common",
 $noNotifyIv = false;                                                // true/false
 $notifyIv = '""';                                                   // "" for empty or a number
 
+$noNotifyIv0 = false;                                                // true/false
+$notifyIv0 = false;                                                // true/false
+
 $noNotifyLevel = false;                                                // true/false
 $notifyLevel = '""';                                                   // "" for empty or a number
 

--- a/pre-index.php
+++ b/pre-index.php
@@ -476,7 +476,7 @@ if ($blockIframe) {
             <?php
             if (!$noNotifyIvZero) {
                 echo '<div class="form-control switch-container">
-                <h3>Notify on 0iv</h3>
+                <h3>Notify on 0 iv</h3>
                 <div class="onoffswitch">
                     <input id="notifyivzero-switch" type="checkbox" name="notifyivzero-switch" class="onoffswitch-checkbox"
                            checked>

--- a/pre-index.php
+++ b/pre-index.php
@@ -700,7 +700,7 @@ if ($blockIframe) {
     var notifyPokemon = <?php echo $noNotifyPokemon ? '[]' : $notifyPokemon ?>;
     var notifyRarity = <?php echo $noNotifyRarity ? '[]' : $notifyRarity ?>;
     var notifyIv = <?php echo $noNotifyIv ? '""' : $notifyIv ?>;
-    var notifyIvZero = <?php echo $noNotifyIvZero ? false : $notifyIvZero ?>;
+    var notifyIvZero = <?php echo $noNotifyIvZero ? 'false' : $notifyIvZero ?>;
     var notifyLevel = <?php echo $noNotifyLevel ? '""' : $notifyLevel ?>;
     var notifyRaid = <?php echo $noNotifyRaid ? 0 : $notifyRaid ?>;
     var enableRaids = <?php echo $noRaids ? 'false' : $enableRaids ?>;

--- a/pre-index.php
+++ b/pre-index.php
@@ -474,6 +474,20 @@ if ($blockIframe) {
             }
             ?>
             <?php
+            if (!$noNotifyIv0) {
+                echo '<div class="form-control switch-container">
+                <h3>Notify on 0iv</h3>
+                <div class="onoffswitch">
+                    <input id="notifyiv0-switch" type="checkbox" name="notifyiv0-switch" class="onoffswitch-checkbox"
+                           checked>
+                    <label class="onoffswitch-label" for="notifyiv0-switch">
+                        <span class="switch-label" data-on="On" data-off="Off"></span>
+                        <span class="switch-handle"></span>
+                    </label>
+                </div></div>';
+            }
+            ?>
+            <?php
             if (!$noNotifyLevel) {
                 echo '<div class="form-control">
                 <label for="notify-level">

--- a/pre-index.php
+++ b/pre-index.php
@@ -474,13 +474,13 @@ if ($blockIframe) {
             }
             ?>
             <?php
-            if (!$noNotifyIv0) {
+            if (!$noNotifyIvZero) {
                 echo '<div class="form-control switch-container">
                 <h3>Notify on 0iv</h3>
                 <div class="onoffswitch">
-                    <input id="notifyiv0-switch" type="checkbox" name="notifyiv0-switch" class="onoffswitch-checkbox"
+                    <input id="notifyivzero-switch" type="checkbox" name="notifyivzero-switch" class="onoffswitch-checkbox"
                            checked>
-                    <label class="onoffswitch-label" for="notifyiv0-switch">
+                    <label class="onoffswitch-label" for="notifyivzero-switch">
                         <span class="switch-label" data-on="On" data-off="Off"></span>
                         <span class="switch-handle"></span>
                     </label>
@@ -700,6 +700,7 @@ if ($blockIframe) {
     var notifyPokemon = <?php echo $noNotifyPokemon ? '[]' : $notifyPokemon ?>;
     var notifyRarity = <?php echo $noNotifyRarity ? '[]' : $notifyRarity ?>;
     var notifyIv = <?php echo $noNotifyIv ? '""' : $notifyIv ?>;
+    var notifyIvZero = <?php echo $noNotifyIvZero ? false : $notifyIvZero ?>;
     var notifyLevel = <?php echo $noNotifyLevel ? '""' : $notifyLevel ?>;
     var notifyRaid = <?php echo $noNotifyRaid ? 0 : $notifyRaid ?>;
     var enableRaids = <?php echo $noRaids ? 'false' : $enableRaids ?>;

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -869,6 +869,11 @@ var StoreOptions = {
             default: notifyIv,
             type: StoreTypes.Number
         },
+    'remember_show_ivzero':
+        {
+            default: notifyIvZero,
+            type: StoreTypes.Boolean
+        },
     'remember_text_level_notify':
         {
             default: notifyLevel,

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -323,6 +323,7 @@ function initSidebar() {
     $('#spawnpoints-switch').prop('checked', Store.get('showSpawnpoints'))
     $('#ranges-switch').prop('checked', Store.get('showRanges'))
     $('#sound-switch').prop('checked', Store.get('playSound'))
+    $('#notifyivzero-switch').prop('checked', Store.get('remember_show_ivzero'))
     $('#cries-switch').prop('checked', Store.get('playCries'))
     $('#cries-switch-wrapper').toggle(Store.get('playSound'))
     $('#cries-type-filter-wrapper').toggle(Store.get('playCries'))
@@ -2586,9 +2587,6 @@ $(function () {
             $textPerfectionNotify.val(notifiedMinPerfection)
             Store.set('remember_text_perfection_notify', notifiedMinPerfection)
         })
-        $selectNotifyIvZero.on('change', function () {
-            Store.set('remember_show_ivzero', this.value)
-        })
         $textLevelNotify.on('change', function (e) {
             notifiedMinLevel = parseInt($textLevelNotify.val(), 10)
             if (isNaN(notifiedMinLevel) || notifiedMinLevel <= 0) {
@@ -2725,6 +2723,9 @@ $(function () {
             wrapper.hide(options)
         }
         return buildSwitchChangeListener(mapData, ['pokestops'], 'showPokestops').bind(this)()
+    })
+    $('#notifyivzero-switch').change(function () {
+         Store.set('remember_show_ivzero', this.checked)
     })
 
     $('#sound-switch').change(function () {

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -842,6 +842,11 @@ function customizePokemonMarker(marker, item, skipNotification) {
                 marker.setAnimation(google.maps.Animation.BOUNCE)
             }
         }
+        if (Store.get('remember_show_ivzero') && perfection < 1) {
+            if (marker.animationDisabled !== true) {
+                marker.setAnimation(google.maps.Animation.BOUNCE)
+            }
+        }
     }
 
     if (item['level'] != null) {

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -842,7 +842,7 @@ function customizePokemonMarker(marker, item, skipNotification) {
                 marker.setAnimation(google.maps.Animation.BOUNCE)
             }
         }
-        if (Store.get('remember_show_ivzero') && perfection < 1) {
+        if (Store.get('remember_show_ivzero') && perfection == 0) {
             if (marker.animationDisabled !== true) {
                 marker.setAnimation(google.maps.Animation.BOUNCE)
             }
@@ -2730,7 +2730,7 @@ $(function () {
         return buildSwitchChangeListener(mapData, ['pokestops'], 'showPokestops').bind(this)()
     })
     $('#notifyivzero-switch').change(function () {
-         Store.set('remember_show_ivzero', this.checked)
+        Store.set('remember_show_ivzero', this.checked)
     })
 
     $('#sound-switch').change(function () {

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -842,7 +842,7 @@ function customizePokemonMarker(marker, item, skipNotification) {
                 marker.setAnimation(google.maps.Animation.BOUNCE)
             }
         }
-        if (Store.get('remember_show_ivzero') && perfection == 0) {
+        if (Store.get('remember_show_ivzero') && perfection === 0) {
             if (marker.animationDisabled !== true) {
                 marker.setAnimation(google.maps.Animation.BOUNCE)
             }

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -842,7 +842,11 @@ function customizePokemonMarker(marker, item, skipNotification) {
                 marker.setAnimation(google.maps.Animation.BOUNCE)
             }
         }
-        if (Store.get('remember_show_ivzero') && perfection === 0) {
+        if ($selectNotifyIvZero && perfection === 0) {
+            if (!skipNotification) {
+                checkAndCreateSound(item['pokemon_id'])
+                sendNotification(getNotifyText(item).fav_title, getNotifyText(item).fav_text, iconpath + item['pokemon_id'] + '.png', item['latitude'], item['longitude'])
+            }
             if (marker.animationDisabled !== true) {
                 marker.setAnimation(google.maps.Animation.BOUNCE)
             }

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -7,6 +7,7 @@ var $selectPokemonNotify
 var $selectRarityNotify
 var $textPerfectionNotify
 var $textLevelNotify
+var $selectNotifyIvZero
 var $raidNotify
 var $selectStyle
 var $selectIconSize
@@ -2500,6 +2501,7 @@ $(function () {
     $selectRarityNotify = $('#notify-rarity')
     $textPerfectionNotify = $('#notify-perfection')
     $textLevelNotify = $('#notify-level')
+    $selectNotifyIvZero = $('#notifyivzero-switch')
     $raidNotify = $('#notify-raid')
     var numberOfPokemon = 386
 
@@ -2584,6 +2586,9 @@ $(function () {
             $textPerfectionNotify.val(notifiedMinPerfection)
             Store.set('remember_text_perfection_notify', notifiedMinPerfection)
         })
+        $selectNotifyIvZero.on('change', function () {
+            Store.set('remember_show_ivzero', this.value)
+        })
         $textLevelNotify.on('change', function (e) {
             notifiedMinLevel = parseInt($textLevelNotify.val(), 10)
             if (isNaN(notifiedMinLevel) || notifiedMinLevel <= 0) {
@@ -2601,6 +2606,7 @@ $(function () {
         $selectPokemonNotify.val(Store.get('remember_select_notify')).trigger('change')
         $selectRarityNotify.val(Store.get('remember_select_rarity_notify')).trigger('change')
         $textPerfectionNotify.val(Store.get('remember_text_perfection_notify')).trigger('change')
+        $selectNotifyIvZero.val(Store.get('remember_show_ivzero')).trigger('change')
         $textLevelNotify.val(Store.get('remember_text_level_notify')).trigger('change')
         $raidNotify.val(Store.get('remember_raid_notify')).trigger('change')
 


### PR DESCRIPTION
Some users want to be notified of 0iv pokemon so this PR allows them to bounce separate from the other minimum iv notification since setting it to 0 would make everything bounce.