### PR TITLE
Incorrect last_scanned column in gym query

### DIFF
--- a/lib/RocketMap.php
+++ b/lib/RocketMap.php
@@ -353,7 +353,7 @@ class RocketMap extends Scanner
             $date = new \DateTime();
             $date->setTimezone(new \DateTimeZone('UTC'));
             $date->setTimestamp($tstamp);
-            $conds[] = "last_scanned > :lastUpdated";
+            $conds[] = "gym.last_scanned > :lastUpdated";
             $params[':lastUpdated'] = date_format($date, 'Y-m-d H:i:s');
         }
 


### PR DESCRIPTION
There are three joined tables in query - gym, gymdetails and raid. All of them has last_scanned column. MariaDB tries to filter query using raid.last_scanned column