### PR TITLE
Separate weight and height from pokemonLabel

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -439,9 +439,14 @@ function pokemonLabel(item) {
         details +=
             '<div>' +
             'Gender: ' + genderType[gender - 1]
-        if (weight != null && height != null) {
-            details += ' | Weight: ' + weight.toFixed(2) + 'kg | Height: ' + height.toFixed(2) + 'm'
+        if (weight != null) {
+            details += ' | Weight: ' + weight.toFixed(2) + 'kg'
         }
+        
+        if (height != null) {
+            details += ' | Height: ' + height.toFixed(2) + 'm'
+        }
+        
         details +=
             '</div>'
     }


### PR DESCRIPTION
Separate weight and height in the pokemonLabel if you only store one or the other.
![image](https://user-images.githubusercontent.com/20814046/34829578-73035a4a-f6e1-11e7-93cd-960bba47041f.png)
