### PR TITLE
Option to display EX Icon only on defined triggerGyms + make Icon always active

### DIFF
--- a/config/default.php
+++ b/config/default.php
@@ -168,7 +168,7 @@ $locationStyle = 'none';                                            // none, goo
 $osmTileServer = 'tile.openstreetmap.org';                          // osm tile server (no trailing slash)
 
 $triggerGyms = '[]';                                                // Add Gyms that the OSM-Query doesn't take care of like '["gym_id", "gym_id"]'
-$onlyTriggerGyms = false;                                           // Only show EX-eligble-Gyms that are defined in $triggerGyms
+$onlyTriggerGyms = false;                                           // Only show EX-Gyms that are defined in $triggerGyms
 $noExGyms = false;                                                  // Do not display EX-Gyms on the map
 $noParkInfo = false;                                                // Do not display Park info on the map
 

--- a/config/default.php
+++ b/config/default.php
@@ -168,6 +168,7 @@ $locationStyle = 'none';                                            // none, goo
 $osmTileServer = 'tile.openstreetmap.org';                          // osm tile server (no trailing slash)
 
 $triggerGyms = '[]';                                                // Add Gyms that the OSM-Query doesn't take care of like '["gym_id", "gym_id"]'
+$onlyTriggerGyms = false;                                           // Only show EX-eligble-Gyms that are defined in $triggerGyms
 $noExGyms = false;                                                  // Do not display EX-Gyms on the map
 $noParkInfo = false;                                                // Do not display Park info on the map
 

--- a/config/example.config.php
+++ b/config/example.config.php
@@ -157,7 +157,7 @@ $locationStyle = 'none';                                            // none, goo
 $osmTileServer = 'tile.openstreetmap.org';                          // osm tile server (no trailing slash)
 
 $triggerGyms = '[]';                                                // Add Gyms that the OSM-Query doesn't take care of like '["gym_id", "gym_id"]'
-$onlyTriggerGyms = false;                                           // Only show EX-eligble-Gyms that are defined in $triggerGyms
+$onlyTriggerGyms = false;                                           // Only show EX-Gyms that are defined in $triggerGyms
 $noExGyms = false;                                                  // Do not display EX-Gyms on the map
 $noParkInfo = false;                                                // Do not display Park info on the map
 

--- a/config/example.config.php
+++ b/config/example.config.php
@@ -157,7 +157,7 @@ $locationStyle = 'none';                                            // none, goo
 $osmTileServer = 'tile.openstreetmap.org';                          // osm tile server (no trailing slash)
 
 $triggerGyms = '[]';                                                // Add Gyms that the OSM-Query doesn't take care of like '["gym_id", "gym_id"]'
-
+$onlyTriggerGyms = false;                                           // Only show EX-eligble-Gyms that are defined in $triggerGyms
 $noExGyms = false;                                                  // Do not display EX-Gyms on the map
 $noParkInfo = false;                                                // Do not display Park info on the map
 

--- a/pre-index.php
+++ b/pre-index.php
@@ -715,6 +715,7 @@ if ($blockIframe) {
     var triggerGyms = <?php echo $triggerGyms ?>;
     var noExGyms = <?php echo $noExGyms === true ? 'true' : 'false' ?>;
     var noParkInfo = <?php echo $noParkInfo === true ? 'true' : 'false' ?>;
+    var onlyTriggerGyms = <?php echo $onlyTriggerGyms === true ? 'true' : 'false' ?>;
 </script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
 <script src="static/dist/js/map.common.min.js"></script>

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -76,8 +76,9 @@ var assetsPath = 'static/sounds/'
 var iconpath = null
 
 var gymTypes = ['Uncontested', 'Mystic', 'Valor', 'Instinct']
-var triggerGyms = Store.get('triggerGyms')
 
+var triggerGyms = Store.get('triggerGyms')
+var onlyTriggerGyms
 var noExGyms
 var noParkInfo
 
@@ -892,8 +893,7 @@ function getGymMarkerIcon(item) {
         teamStr = gymTypes[item['team_id']] + '_' + level
     }
     var exIcon = ''
-
-    if ((((park !== 'None' && park !== undefined) || triggerGyms.includes(item['gym_id'])) && (noExGyms === false))) {
+    if ((((park !== 'None' && park !== undefined && onlyTriggerGyms === false) || triggerGyms.includes(item['gym_id'])) && (noExGyms === false))) {
         exIcon = '<img src="static/images/ex.png" style="position:absolute;right:25px;bottom:2px;"/>'
     }
     if (item['raid_pokemon_id'] != null && item.raid_end > Date.now()) {
@@ -919,6 +919,7 @@ function getGymMarkerIcon(item) {
     } else {
         return '<div>' +
             '<img src="static/forts/' + Store.get('gymMarkerStyle') + '/' + gymTypes[item['team_id']] + '.png" style="width:48px;height: auto;"/>' +
+            exIcon +
             '</div>'
     }
 }

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -919,7 +919,6 @@ function getGymMarkerIcon(item) {
     } else {
         return '<div>' +
             '<img src="static/forts/' + Store.get('gymMarkerStyle') + '/' + gymTypes[item['team_id']] + '.png" style="width:48px;height: auto;"/>' +
-            exIcon +
             '</div>'
     }
 }

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -919,6 +919,7 @@ function getGymMarkerIcon(item) {
     } else {
         return '<div>' +
             '<img src="static/forts/' + Store.get('gymMarkerStyle') + '/' + gymTypes[item['team_id']] + '.png" style="width:48px;height: auto;"/>' +
+            exIcon +
             '</div>'
     }
 }


### PR DESCRIPTION
Added an option to only display EX Icons on trigger Gyms that are defined in config.php

Currently the OSM Query takes recent data to determine what is a park and what is not, Niantic is using data from July 2016 though. So until the Query is fixed you can manually enter ex-eligible gyms in config.php.

Might also come in handy for people who only want the icon on specific gyms.

Example:
```
$triggerGyms = "[
        '754ca6e6bbb24f3b8fa1441099e9f21f.16',
        'bd4617721f5544e6b75bbad83942c601.16',
        '74766deeae3e48268ef346458fa64375.11',
        'a0f11f1721524c9ebc6a64bd58d0218d.11',
        '235c4d25a4674fcf85cbe0e1b7c92369.16',
        'f6a0d8dec55745b28af59b1b70057f76.11',
        '171946ccc5284025a03483439fb335d7.16',
        '8e27c516772b459f8b6c3cd5446262de.16',
        'f40bc5d52d9241b49f70669af541653b.16',
        'c763efd74156469fb82e976a4f6d3036.16',
        '22ec6a9a5ac4464bb5ec912ba4bc9498.16',
        'ece5a26d96244133a6714730ec692b52.16',
        '97c9f6219f954b76a1d0887e43657292.11',
        'f2c0e61283ef4ead9151aa9144d2bf51.16'
]";
$onlyTriggerGyms = true;        // Only show EX-eligble-Gyms that are defined in $triggerGyms
$noExGyms = false;              // Do not display EX-Gyms on the map
$noParkInfo = false;            // Do not display Park info on the map
```
This will only display ex-icons on the gyms defined in $triggerGyms