### PR TITLE
Allow Multiple api keys on map

### DIFF
--- a/config/default.php
+++ b/config/default.php
@@ -48,7 +48,7 @@ $locale = "en";                                                     // Display l
 
 /* Google Maps Key */
 
-$gmapsKey = "";                                                     // Google Maps API Key
+$gmapsKey = [""];                                                     // Google Maps API Key ["KEY1","KEY2"]
 
 /* Google Analytics */
 

--- a/config/example.config.php
+++ b/config/example.config.php
@@ -37,7 +37,7 @@ $locale = "en";                                                     // Display l
 
 /* Google Maps Key */
 
-$gmapsKey = "";                                                     // Google Maps API Key
+$gmapsKey = [""];                                                     // Google Maps API Key ["KEY1","KEY2"]
 
 /* Google Analytics */
 

--- a/pre-index.php
+++ b/pre-index.php
@@ -814,7 +814,7 @@ if ($blockIframe) {
 <script src="static/dist/js/map.min.js"></script>
 <script src="static/dist/js/stats.min.js"></script>
 <script defer
-        src="https://maps.googleapis.com/maps/api/js?key=<?= $gmapsKey[mt_rand( 0, count($gmapsKey) - 1 )] ?>&amp;callback=initMap&amp;libraries=places,geometry"></script>
+        src="https://maps.googleapis.com/maps/api/js?key=<?= $gmapsKey[mt_rand(0, count($gmapsKey) - 1)] ?>&amp;callback=initMap&amp;libraries=places,geometry"></script>
 <script defer src="static/js/vendor/richmarker-compiled.js"></script>
 </body>
 </html>

--- a/pre-index.php
+++ b/pre-index.php
@@ -814,7 +814,7 @@ if ($blockIframe) {
 <script src="static/dist/js/map.min.js"></script>
 <script src="static/dist/js/stats.min.js"></script>
 <script defer
-        src="https://maps.googleapis.com/maps/api/js?key=<?= $gmapsKey ?>&amp;callback=initMap&amp;libraries=places,geometry"></script>
+        src="https://maps.googleapis.com/maps/api/js?key=<?= $gmapsKey[mt_rand( 0, count($gmapsKey) - 1 )] ?>&amp;callback=initMap&amp;libraries=places,geometry"></script>
 <script defer src="static/js/vendor/richmarker-compiled.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Use this PR at your own risk as its technically against Google ToS. I was asked to put together a way for people to use multiple google maps keys. Just add the keys  into the config file as in the example.config and it will choose a random one each time it loads the page.