### PR TITLE
Fix Monocle/Alternative out of memory with KEEP_GYM_HISTORY

### DIFF
--- a/config/default.php
+++ b/config/default.php
@@ -238,3 +238,4 @@ $enableDebug = false;
 //-----------------------------------------------------
 
 $fork = "default";                                                  // default/asner/sloppy
+$alternateKeepGymHistory = false;                                   // alternate - KEEP_GYM_HISTORY is on

--- a/config/example.config.php
+++ b/config/example.config.php
@@ -228,6 +228,7 @@ $enableDebug = false;
 
 $map = "monocle";                                                   // monocle/rm
 $fork = "default";                                                  // default/asner/sloppy/alternate
+$alternateKeepGymHistory = false;                                   // alternate - KEEP_GYM_HISTORY is on
 
 $db = new Medoo([// required
     'database_type' => 'mysql',                                     // mysql/mariadb/pgsql/sybase/oracle/mssql/sqlite

--- a/lib/Monocle_Alternate.php
+++ b/lib/Monocle_Alternate.php
@@ -214,7 +214,7 @@ class Monocle_Alternate extends Monocle
 
     public function query_gyms($conds, $params)
     {
-        global $db;
+        global $db, $alternateKeepGymHistory;
 
         $query = "SELECT
         f.external_id AS gym_id,
@@ -236,10 +236,15 @@ class Monocle_Alternate extends Monocle
         r.move_1 AS raid_pokemon_move_1,
         r.move_2 AS raid_pokemon_move_2
         FROM forts f
-        LEFT JOIN fort_sightings fs ON (fs.fort_id = f.id AND fs.last_modified = (SELECT MAX(last_modified) FROM fort_sightings fs2 WHERE fs2.fort_id=f.id))
+        LEFT JOIN fort_sightings fs ON (fs.fort_id = f.id AND :fort_condition)
         LEFT JOIN raids r ON (r.fort_id = f.id AND r.time_end >= :time)
         WHERE :conditions";
 
+        if ($alternateKeepGymHistory) {
+            $query = str_replace(":fort_condition", "fs.last_modified = (SELECT MAX(last_modified) FROM fort_sightings fs2 WHERE fs2.fort_id=f.id)", $query);
+        } else {
+            $query = str_replace(":fort_condition", "1=1", $query);
+        }
         $query = str_replace(":time", time(), $query);
         $query = str_replace(":conditions", join(" AND ", $conds), $query);
         $gyms = $db->query($query, $params)->fetchAll(\PDO::FETCH_ASSOC);

--- a/lib/Monocle_Alternate.php
+++ b/lib/Monocle_Alternate.php
@@ -216,7 +216,8 @@ class Monocle_Alternate extends Monocle
     {
         global $db;
 
-        $query = "SELECT f.external_id AS gym_id,
+        $query = "SELECT
+        f.external_id AS gym_id,
         fs.last_modified AS last_modified,
         updated AS last_scanned,
         f.lat AS latitude,
@@ -235,10 +236,11 @@ class Monocle_Alternate extends Monocle
         r.move_1 AS raid_pokemon_move_1,
         r.move_2 AS raid_pokemon_move_2
         FROM forts f
-        LEFT JOIN fort_sightings fs ON fs.fort_id = f.id
-        LEFT JOIN raids r ON r.fort_id = f.id
+        LEFT JOIN fort_sightings fs ON (fs.fort_id = f.id AND fs.last_modified = (SELECT MAX(last_modified) FROM fort_sightings fs2 WHERE fs2.fort_id=f.id))
+        LEFT JOIN raids r ON (r.fort_id = f.id AND r.time_end >= :time)
         WHERE :conditions";
 
+        $query = str_replace(":time", time(), $query);
         $query = str_replace(":conditions", join(" AND ", $conds), $query);
         $gyms = $db->query($query, $params)->fetchAll(\PDO::FETCH_ASSOC);
 


### PR DESCRIPTION
When `KEEP_GYM_HISTORY` is on in Monocle/Alternative config, the `fort_sighting` and `raid` may contain multiple records of the same gym. Only the latest gym / fort status should be retrieved to avoid out of memory problem.