### PR TITLE
Battle statistics for Pokemon in gyms [Monocle/Alt]

### DIFF
--- a/config/default.php
+++ b/config/default.php
@@ -104,6 +104,7 @@ $enableGyms = 'false';                                              // true/fals
 $noGymSidebar = false;                                              // true/false
 $gymSidebar = 'true';                                               // true/false
 $noTrainerName = false;                                             // true/false
+$noPokemonBattleInfo = false;                                       // true/false
 
 $noRaids = false;                                                   // true/false
 $enableRaids = 'false';                                             // true/false

--- a/config/example.config.php
+++ b/config/example.config.php
@@ -94,6 +94,7 @@ $enableGyms = 'false';                                              // true/fals
 $noGymSidebar = false;                                              // true/false
 $gymSidebar = 'true';                                               // true/false
 $noTrainerName = false;                                             // true/false
+$noPokemonBattleInfo = false;                                       // true/false
 
 $noRaids = false;                                                   // true/false
 $enableRaids = 'false';                                             // true/false

--- a/lib/Monocle_Alternate.php
+++ b/lib/Monocle_Alternate.php
@@ -197,10 +197,15 @@ class Monocle_Alternate extends Monocle
         $gym = $gyms[0];
 
         $select = "gd.pokemon_id, gd.cp AS pokemon_cp, gd.move_1, gd.move_2, gd.nickname, gd.atk_iv AS iv_attack, gd.def_iv AS iv_defense, gd.sta_iv AS iv_stamina, gd.cp AS pokemon_cp";
+        global $noPokemonBattleInfo;
+        if (!$noPokemonBattleInfo) {
+            $select .= ", gd.battles_attacked as attacked, gd.battles_defended as defended";
+        }
         global $noTrainerName;
         if (!$noTrainerName) {
             $select .= ", gd.owner_name AS trainer_name";
         }
+
         $gym["pokemon"] = $this->query_gym_defenders($gymId, $select);
         return $gym;
     }

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -2403,6 +2403,10 @@ function showGymDetails(id) { // eslint-disable-line no-unused-vars
                     pokemonHtml +=
                         '<div style="line-height: 1em">' + pokemon.trainer_name + '</div>'
                 }
+                if (pokemon.attacked) {
+                    pokemonHtml +=
+                        '<div style="line-height: 1em">' + i8ln('A') + ': ' + pokemon.attacked + ' | ' + i8ln('D') + ': ' + pokemon.defended + '</div>'
+                }
                 pokemonHtml +=
                     '</td>' +
                     '<td width="10">' +

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -2403,7 +2403,7 @@ function showGymDetails(id) { // eslint-disable-line no-unused-vars
                     pokemonHtml +=
                         '<div style="line-height: 1em">' + pokemon.trainer_name + '</div>'
                 }
-                if (pokemon.attacked) {
+                if (pokemon.attacked && pokemon.defended) {
                     pokemonHtml +=
                         '<div style="line-height: 1em">' + i8ln('A') + ': ' + pokemon.attacked + ' | ' + i8ln('D') + ': ' + pokemon.defended + '</div>'
                 }

--- a/static/locales/de.json
+++ b/static/locales/de.json
@@ -988,5 +988,6 @@
   "Cloudy":"Bedeckt",
   "Windy":"Windig",
   "Snow":"Schnee",
-  "Fog":"Nebel"
+  "Fog":"Nebel",
+  "D": "V"
 }


### PR DESCRIPTION
Displays battle statistics in the sidebar for Pokemon that are currently deployed in gyms.

Can be turned off in config.

![image](https://user-images.githubusercontent.com/29790503/35791325-94942120-0a47-11e8-8659-f2019310f81c.png)
