### PR TITLE
Fix data-usage if minIV or minLevel is empty

### DIFF
--- a/raw_data.php
+++ b/raw_data.php
@@ -40,7 +40,7 @@ $d["lastgyms"] = !empty($_POST['gyms']) ? $_POST['gyms'] : false;
 $d["lastslocs"] = !empty($_POST['scanned']) ? $_POST['scanned'] : false;
 $d["lastspawns"] = !empty($_POST['spawnpoints']) ? $_POST['spawnpoints'] : false;
 $d["lastpokemon"] = !empty($_POST['pokemon']) ? $_POST['pokemon'] : false;
-if ($minIv < $prevMinIv || $minLevel < $prevMinLevel) {
+if (intval($minIv) < intval($prevMinIv) || intval($minLevel) < intval($prevMinLevel)) {
     $lastpokemon = false;
 }
 $enc_id = !empty($_POST['encId']) ? $_POST['encId'] : null;


### PR DESCRIPTION
If minIV or minLevel is empty lastpokemon would always be false and therefore it would ignore the timestamp.
 